### PR TITLE
Add Go's dep tool and upgrade to to 1.9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,21 @@ FROM ubuntu:16.04
 
 # Install base packages, ansible, nodejs
 RUN apt-get update && apt-get -y install \
-        awscli \
-        curl \
-        dnsutils \
-        gcc \
-        git \
-        jq \
-        software-properties-common \
-        unzip \
-        wget && \
+    awscli \
+    curl \
+    dnsutils \
+    gcc \
+    git \
+    jq \
+    software-properties-common \
+    unzip \
+    wget && \
     apt-add-repository ppa:ansible/ansible && \
     apt-get update && apt-get -y install \
-        ansible && \
+    ansible && \
     bash -o pipefail -c "curl -L https://deb.nodesource.com/setup_6.x | bash" && \
     apt-get -y install \
-        nodejs && \
+    nodejs && \
     rm -rf /var/lib/apt/lists/*
 
 # Install bosh-cli
@@ -38,11 +38,12 @@ RUN mkdir -p /go/bin && \
 
 # Install go tools
 RUN go get \
-        github.com/GeertJohan/fgt \
-        github.com/golang/lint/golint \
-        github.com/govau/sdget \
-        github.com/jteeuwen/go-bindata/... \
-        golang.org/x/tools/cmd/cover
+    github.com/golang/dep/cmd/dep \
+    github.com/GeertJohan/fgt \
+    github.com/golang/lint/golint \
+    github.com/govau/sdget \
+    github.com/jteeuwen/go-bindata/... \
+    golang.org/x/tools/cmd/cover
 
 # Install common NPM stuff, and:
 # Fix bug https://github.com/npm/npm/issues/9863

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN curl -L https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-2.0.40-linux-am
 # Install credhub-cli
 RUN bash -o pipefail -c "curl -L https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/1.4.1/credhub-linux-1.4.1.tgz | tar -xz -C /usr/local/bin"
 
-# Install modern golang
-RUN bash -o pipefail -c "curl -L https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz | tar -xz -C /usr/local"
+# Install go
+RUN bash -o pipefail -c "curl -L https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz | tar -xz -C /usr/local"
 
 # Set Go environment variables
 ENV GOROOT=/usr/local/go GOPATH=/go PATH=/go/bin:/usr/local/go/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,21 @@ FROM ubuntu:16.04
 
 # Install base packages, ansible, nodejs
 RUN apt-get update && apt-get -y install \
-    awscli \
-    curl \
-    dnsutils \
-    gcc \
-    git \
-    jq \
-    software-properties-common \
-    unzip \
-    wget && \
+        awscli \
+        curl \
+        dnsutils \
+        gcc \
+        git \
+        jq \
+        software-properties-common \
+        unzip \
+        wget && \
     apt-add-repository ppa:ansible/ansible && \
     apt-get update && apt-get -y install \
-    ansible && \
+        ansible && \
     bash -o pipefail -c "curl -L https://deb.nodesource.com/setup_6.x | bash" && \
     apt-get -y install \
-    nodejs && \
+        nodejs && \
     rm -rf /var/lib/apt/lists/*
 
 # Install bosh-cli
@@ -38,12 +38,12 @@ RUN mkdir -p /go/bin && \
 
 # Install go tools
 RUN go get \
-    github.com/golang/dep/cmd/dep \
-    github.com/GeertJohan/fgt \
-    github.com/golang/lint/golint \
-    github.com/govau/sdget \
-    github.com/jteeuwen/go-bindata/... \
-    golang.org/x/tools/cmd/cover
+        github.com/golang/dep/cmd/dep \
+        github.com/GeertJohan/fgt \
+        github.com/golang/lint/golint \
+        github.com/govau/sdget \
+        github.com/jteeuwen/go-bindata/... \
+        golang.org/x/tools/cmd/cover
 
 # Install common NPM stuff, and:
 # Fix bug https://github.com/npm/npm/issues/9863


### PR DESCRIPTION
Leave glide in there for the time being until we are happy that we don't
need to use it anymore for anything else.

P.S. looks like my editor auto-fixes Dockerfile formatting errors, hence the extra diff...